### PR TITLE
Mesh rc 0.4.2

### DIFF
--- a/app/cmd/rpc/mesh/app.go
+++ b/app/cmd/rpc/mesh/app.go
@@ -26,7 +26,7 @@ const (
 	ServicerRelayEndpoint   = "/v1/private/mesh/relay"
 	ServicerSessionEndpoint = "/v1/private/mesh/session"
 	ServicerCheckEndpoint   = "/v1/private/mesh/check"
-	AppVersion              = "RC-0.4.1"
+	AppVersion              = "RC-0.4.2"
 )
 
 var (

--- a/app/cmd/rpc/mesh/app.go
+++ b/app/cmd/rpc/mesh/app.go
@@ -26,7 +26,7 @@ const (
 	ServicerRelayEndpoint   = "/v1/private/mesh/relay"
 	ServicerSessionEndpoint = "/v1/private/mesh/session"
 	ServicerCheckEndpoint   = "/v1/private/mesh/check"
-	AppVersion              = "RC-0.4.2"
+	AppVersion              = "BETA-0.4.2"
 )
 
 var (

--- a/app/cmd/rpc/mesh/app.go
+++ b/app/cmd/rpc/mesh/app.go
@@ -26,7 +26,7 @@ const (
 	ServicerRelayEndpoint   = "/v1/private/mesh/relay"
 	ServicerSessionEndpoint = "/v1/private/mesh/session"
 	ServicerCheckEndpoint   = "/v1/private/mesh/check"
-	AppVersion              = "BETA-0.4.2"
+	AppVersion              = "RC-0.4.2"
 )
 
 var (

--- a/app/cmd/rpc/mesh/relay.go
+++ b/app/cmd/rpc/mesh/relay.go
@@ -403,7 +403,7 @@ func validate(r *pocketTypes.Relay) (*NodeSession, sdk.Error) {
 		r.Proof.Blockchain,
 		ns.ServicerAddress,
 	))
-	return ns, pocketTypes.NewInvalidSessionKeyError(ModuleName, e2)
+	return nil, pocketTypes.NewInvalidSessionKeyError(ModuleName, e2)
 
 }
 

--- a/app/cmd/rpc/mesh/relay.go
+++ b/app/cmd/rpc/mesh/relay.go
@@ -35,11 +35,11 @@ func storeRelayProofToDisk(relay *pocketTypes.Relay) {
 	return
 }
 
-func addRelayToDuplicateSet(relay *pocketTypes.Relay, ns *NodeSession) {
+func addRelayProofToDuplicateSet(relayProof *pocketTypes.RelayProof, ns *NodeSession) {
 	if ns == nil {
 		return
 	}
-	ns.AddRelayToDuplicateSet(relay)
+	ns.AddRelayProofToDuplicateSet(relayProof)
 }
 
 // decodeCacheRelay - decode []byte relay from cache to pocketTypes.Relay
@@ -382,7 +382,7 @@ func validate(r *pocketTypes.Relay) (*NodeSession, sdk.Error) {
 		return nil, pocketTypes.NewInvalidSessionKeyError(ModuleName, err)
 	}
 
-	if ns.IsDuplicateRelay(r) {
+	if ns.IsDuplicateRelayProof(&r.Proof) {
 		return nil, pocketTypes.NewDuplicateProofError(ModuleName)
 	}
 
@@ -463,7 +463,7 @@ func HandleRelay(r *pocketTypes.Relay) (res *pocketTypes.RelayResponse, dispatch
 	storeRelayProofToDisk(r)
 
 	// Add relay to our duplicate set to prevent handling repeated relays sent from apps.
-	addRelayToDuplicateSet(r, ns)
+	addRelayProofToDuplicateSet(&r.Proof, ns)
 
 	blockChainCallStart := time.Now()
 	res, err = processRelay(r)

--- a/app/cmd/rpc/mesh/relay.go
+++ b/app/cmd/rpc/mesh/relay.go
@@ -456,7 +456,7 @@ func HandleRelay(r *pocketTypes.Relay) (res *pocketTypes.RelayResponse, dispatch
 		return
 	}
 
-	// store relay on cache and add to bloom filter; once we hit this point this relay will be processed so should be notified to servicer even
+	// store relay on cache; once we hit this point this relay will be processed so should be notified to servicer even
 	// if process is shutdown
 	storeRelay(r)
 

--- a/app/cmd/rpc/mesh/session.go
+++ b/app/cmd/rpc/mesh/session.go
@@ -225,10 +225,10 @@ func (ns *NodeSession) ValidateSessionTask() func() {
 	}
 }
 
-func (ns *NodeSession) IsDuplicateRelay(relay *pocketTypes.Relay) bool {
+func (ns *NodeSession) IsDuplicateRelayProof(relayProof *pocketTypes.RelayProof) bool {
 
 	if ns.DuplicateRelayBloomFilter != nil {
-		return ns.DuplicateRelayBloomFilter.Test(relay.Bytes())
+		return ns.DuplicateRelayBloomFilter.Test(relayProof.Hash())
 	}
 
 	// This might only happen whenever we are swapping in between relaySet to optimisticSet
@@ -236,21 +236,21 @@ func (ns *NodeSession) IsDuplicateRelay(relay *pocketTypes.Relay) bool {
 		return false
 	}
 
-	_, exists := ns.OptimisticDuplicateRelayMap.Load(string(relay.Bytes()))
+	_, exists := ns.OptimisticDuplicateRelayMap.Load(string(relayProof.Hash()))
 	return exists
 }
 
-func (ns *NodeSession) AddRelayToDuplicateSet(relay *pocketTypes.Relay) {
+func (ns *NodeSession) AddRelayProofToDuplicateSet(relayProof *pocketTypes.RelayProof) {
 	// Add to bloom filter if it exists
 	if ns.DuplicateRelayBloomFilter != nil {
-		ns.DuplicateRelayBloomFilter.Add(relay.Proof.Bytes())
+		ns.DuplicateRelayBloomFilter.Add(relayProof.Hash())
 		return
 	}
 
 	// Nil check is just for safety precautions incase we swapping in between relay map and bloom filter.
 	// Otherwise add it to our optimistic relay set
 	if ns.OptimisticDuplicateRelayMap != nil {
-		ns.OptimisticDuplicateRelayMap.Store(string(relay.Bytes()), struct{}{})
+		ns.OptimisticDuplicateRelayMap.Store(string(relayProof.Hash()), struct{}{})
 		return
 	}
 }

--- a/app/cmd/rpc/mesh/session.go
+++ b/app/cmd/rpc/mesh/session.go
@@ -412,22 +412,23 @@ func (ss *SessionStorage) NewNodeSessionFromRelay(relay *pocketTypes.Relay) (*No
 	}
 
 	return &NodeSession{
-		Key:             ss.GetSessionKeyByRelay(relay),
-		Hash:            sessionHash,
-		AppPubKey:       relay.Proof.Token.ApplicationPublicKey,
-		Chain:           relay.Proof.Blockchain,
-		ServicerPubKey:  relay.Proof.ServicerPubKey,
-		ServicerAddress: servicerAddress,
-		BlockHeight:     relay.Proof.SessionBlockHeight,
-		Dispatch:        nil,
-		Queue:           false,
-		Queried:         false,
-		RetryTimes:      0,
-		RelayMeta:       &relay.Meta,
-		ServicerNode:    servicerNode,
-		RemainingRelays: -1,   // means that is unlimited until check it
-		IsValid:         true, // true until fullNode negate this
-		Error:           nil,
+		Key:                         ss.GetSessionKeyByRelay(relay),
+		Hash:                        sessionHash,
+		AppPubKey:                   relay.Proof.Token.ApplicationPublicKey,
+		Chain:                       relay.Proof.Blockchain,
+		ServicerPubKey:              relay.Proof.ServicerPubKey,
+		ServicerAddress:             servicerAddress,
+		BlockHeight:                 relay.Proof.SessionBlockHeight,
+		Dispatch:                    nil,
+		Queue:                       false,
+		Queried:                     false,
+		RetryTimes:                  0,
+		RelayMeta:                   &relay.Meta,
+		ServicerNode:                servicerNode,
+		RemainingRelays:             -1,   // means that is unlimited until check it
+		IsValid:                     true, // true until fullNode negate this
+		Error:                       nil,
+		OptimisticDuplicateRelayMap: xsync.NewMapOf[struct{}](),
 	}, nil
 }
 

--- a/app/cmd/rpc/mesh/session.go
+++ b/app/cmd/rpc/mesh/session.go
@@ -125,7 +125,7 @@ type NodeSession struct {
 	RemainingRelays int64             // how many relays the servicer can still service - todo: probably will remove and handle the overServiceError from the fullNode
 	IsValid         bool              // if the session is or not valid
 	Error           *SdkErrorResponse // in case session is not valid anymore, this will be the error to be returned.
-	bloomFilter     *bloom.BloomFilter
+	BloomFilter     *bloom.BloomFilter
 }
 
 func (ns *NodeSession) CountRelay() bool {
@@ -205,8 +205,8 @@ func (ns *NodeSession) ValidateSessionTask() func() {
 			ns.RemainingRelays = remainingRelays
 
 			// initialize bloom filter once we are able to retrieve a session
-			if ns.bloomFilter == nil {
-				ns.bloomFilter = bloom.NewWithEstimates(uint(float64(remainingRelays)*bloomFilterBuffer), .01)
+			if ns.BloomFilter == nil {
+				ns.BloomFilter = bloom.NewWithEstimates(uint(float64(remainingRelays)*bloomFilterBuffer), .01)
 			}
 		} else if result.Error != nil {
 			ns.IsValid = !ShouldInvalidateSession(result.Error.Code)

--- a/app/cmd/rpc/mesh/session.go
+++ b/app/cmd/rpc/mesh/session.go
@@ -236,7 +236,7 @@ func (ns *NodeSession) IsDuplicateRelay(relay *pocketTypes.Relay) bool {
 		return false
 	}
 
-	_, exists := ns.OptimisticDuplicateRelayMap.Load(relay.RequestHashString())
+	_, exists := ns.OptimisticDuplicateRelayMap.Load(string(relay.Bytes()))
 	return exists
 }
 
@@ -250,7 +250,7 @@ func (ns *NodeSession) AddRelayToDuplicateSet(relay *pocketTypes.Relay) {
 	// Nil check is just for safety precautions incase we swapping in between relay map and bloom filter.
 	// Otherwise add it to our optimistic relay set
 	if ns.OptimisticDuplicateRelayMap != nil {
-		ns.OptimisticDuplicateRelayMap.Store(relay.RequestHashString(), relay)
+		ns.OptimisticDuplicateRelayMap.Store(string(relay.Bytes()), relay)
 		return
 	}
 }


### PR DESCRIPTION
## Description

# Submitting Proof bug
1. Whenever the evidence does not match the total proofs, the node tries to delete the evidence and submits a claim. It should never submit a proof whenever there is LESS than the number of relay proofs as that can cause an array index of out-bounds exception if the randomly selected index is more than what we have in the store. This can cause a node crash. The fix to this is to change to see if the number of relay proofs in the evidence store is less than the submitted claims total relay proofs, and if so, delete the evidence and don't submit a proof.

2. There is a potential race condition where the evidence is not sealed while submitting a claim, allowing for more relays to enter the evidence claim. Whenever a proof is generated via `GenerateMerkleRoot`, it will result in an incorrect Merkle proof from being generated due to mismatch.
- In order to allow for a best-effort process to submit proof for the claim the servicer submitted, we will calculate the `maxRelays` based off:
  1. Use the claim's total proof if the proof count doesn't exceed the maximum relays per session.
  2. Otherwise, fallback to the maximum relays per session.
  
The `GenerateMerkleRoot` already accepts a `maxRelays` parameter which was introduced to fix the Chocalate Rain/Overservicing vulnerability. It discards relays above maxRelays with the following implementation
```go
	if int64(len(ev.Proofs)) > maxRelays {
		ev.Proofs = ev.Proofs[:maxRelays]
		ev.NumOfProofs = maxRelays
	}
```  
  
Note: The more ideal solution is to only submit the claim whenever we are done servicing for sure, but this involves locks and potential side effects that Pocket core was never really built with in mind

# Duplicate Proof Bug
In Pocket Core, in order to prevent the same request hash (relay proof) being serviced, we store the relays in a bloom filter (a memory efficient data structure in determining if an item is in a set, with the tradeoff of some false positives). I added the same functionality in mesh. Once we retrieve the number of relays available in the session, then we initialize the bloom filter as part of the node session. Once the worker starts processing the relay, the first thing we will do is add it to the bloom filter then send it to the full node (servicer)