### PR TITLE
Fix errors, response error serialization, enhance logs and code cleanup.

### DIFF
--- a/app/cmd/rpc/mesh.go
+++ b/app/cmd/rpc/mesh.go
@@ -59,7 +59,7 @@ func meshNodeRelay(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 				if re != nil {
 					mesh.GetLogger().Error(fmt.Sprintf("error marshaling relay error=%s", re.Error()))
 				}
-				if re != nil {
+				if rhe != nil {
 					mesh.GetLogger().Error(fmt.Sprintf("error marshaling request.Header error=%s", rhe.Error()))
 				}
 			}
@@ -67,7 +67,7 @@ func meshNodeRelay(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 
 		response := mesh.RPCRelayResponse{
 			Success:  false,
-			Error:    mesh.NewSdkErrorFromPocketSdkError(sdk.ErrInternal(err.Error())),
+			Error:    mesh.NewSdkErrorFromPocketSdkError(err),
 			Dispatch: dispatch,
 		}
 		j, _ := json.Marshal(response)
@@ -427,16 +427,6 @@ func meshServicerNodeCheck(w http.ResponseWriter, r *http.Request, ps httprouter
 		return
 	}
 
-	if err != nil {
-		response := mesh.RPCSessionResult{
-			Success: false,
-			Error:   mesh.NewSdkErrorFromPocketSdkError(sdk.ErrInternal(err.Error())),
-		}
-		j, _ := json.Marshal(response)
-		WriteJSONResponseWithCode(w, string(j), r.URL.Path, r.Host, 400)
-		return
-	}
-
 	response := mesh.CheckResponse{
 		Success:                    true,
 		Status:                     health,
@@ -462,7 +452,7 @@ func meshServicerNodeCheck(w http.ResponseWriter, r *http.Request, ps httprouter
 				response.WrongServicers = append(response.WrongServicers, address)
 			}
 		} else {
-			// get self node (your validator) from the current state
+			// get self-node (your validator) from the current state
 			node := pocketTypes.GetPocketNode()
 			nodeAddress := node.GetAddress()
 			if nodeAddress.String() != address {

--- a/app/cmd/rpc/mesh/app.go
+++ b/app/cmd/rpc/mesh/app.go
@@ -26,7 +26,7 @@ const (
 	ServicerRelayEndpoint   = "/v1/private/mesh/relay"
 	ServicerSessionEndpoint = "/v1/private/mesh/session"
 	ServicerCheckEndpoint   = "/v1/private/mesh/check"
-	AppVersion              = "RC-0.5.1"
+	AppVersion              = "RC-0.5.2"
 )
 
 var (
@@ -38,7 +38,7 @@ var (
 	relaysClient      *retryablehttp.Client
 	relaysCacheDb     *pogreb.DB
 	servicerMap       = xsync.NewMapOf[*servicer]()
-	nodesMap          = xsync.NewMapOf[*fullNode]()
+	nodesMap          = xsync.NewMapOf[*FullNode]()
 	servicerList      []string
 	chains            *pocketTypes.HostedBlockchains
 	meshAuthToken     sdk.AuthToken
@@ -142,7 +142,7 @@ func StopRPC() {
 	// stop accepting new tasks and signal all workers to stop processing new tasks. Tasks being processed by workers
 	// will continue until completion unless the process is terminated.
 	logger.Info("stopping worker pools...")
-	nodesMap.Range(func(key string, node *fullNode) bool {
+	nodesMap.Range(func(key string, node *FullNode) bool {
 		node.stop()
 		return true
 	})

--- a/app/cmd/rpc/mesh/fullnode.go
+++ b/app/cmd/rpc/mesh/fullnode.go
@@ -20,8 +20,8 @@ import (
 	"time"
 )
 
-// fullNode - represent the pocket client instance running that could handle 1 or N addresses (lean)
-type fullNode struct {
+// FullNode - represent the pocket client instance running that could handle 1 or N addresses (lean)
+type FullNode struct {
 	Name                       string
 	URL                        string
 	Servicers                  *xsync.MapOf[string, *servicer]
@@ -33,7 +33,7 @@ type fullNode struct {
 	Crons                      *cron.Cron
 }
 
-func (node *fullNode) ShouldAssumeOptimisticSession(dispatcherSessionBlockHeight int64) bool {
+func (node *FullNode) ShouldAssumeOptimisticSession(dispatcherSessionBlockHeight int64) bool {
 	fullNodeHeight := node.Status.Height
 	blocksPerSession := node.BlocksPerSession
 	servicerNodeSessionBlockHeight := node.GetLatestSessionBlockHeight()
@@ -42,20 +42,15 @@ func (node *fullNode) ShouldAssumeOptimisticSession(dispatcherSessionBlockHeight
 	isDispatcherAhead := dispatcherSessionBlockHeight >= fullNodeHeight
 	// check if not is at the end of his session
 	isFullNodeAtEndOfSession := (fullNodeHeight % blocksPerSession) == 0
-	// check if the difference between fullNode and the relay session height is really close to avoid someone could abuse
+	// check if the difference between FullNode and the relay session height is really close to avoid someone could abuse
 	// of this optimistic approach.
 	isDispatcherWithinTolerance := (dispatcherSessionBlockHeight - servicerNodeSessionBlockHeight) <= blocksPerSession
 
 	return isDispatcherAhead && isFullNodeAtEndOfSession && isDispatcherWithinTolerance
 }
 
-func (node *fullNode) CanHandleRelayWithinTolerance(dispatcherSessionBlockHeight int64) bool {
-	// Reduce the amount in one to reduce the number of relays rejected by the node due to evidence sealed (code=90)
-	// if the servicer allows 1, mesh will allow 0, so mesh has 1 block to keep notifying servicer about relays on
-	// servicer queue.
-	// The best here is set the Servicer in 2 or 3 so mesh will receive slow session rotation from gateways up to 1 or 2
-	// blocks
-	clientSessionSyncAllowance := math.Max(float64(0), float64(node.ClientSessionSyncAllowance-1))
+func (node *FullNode) CanHandleRelayWithinTolerance(dispatcherSessionBlockHeight int64) bool {
+	clientSessionSyncAllowance := math.Max(float64(0), float64(node.ClientSessionSyncAllowance))
 
 	return pocketTypes.IsProofSessionHeightWithinTolerance(
 		node.GetLatestSessionBlockHeight(),
@@ -66,7 +61,7 @@ func (node *fullNode) CanHandleRelayWithinTolerance(dispatcherSessionBlockHeight
 }
 
 // NewWorker - generate a new worker.
-func (node *fullNode) NewWorker() {
+func (node *FullNode) NewWorker() {
 	node.Worker = NewWorkerPool(
 		node.URL,
 		app.GlobalMeshConfig.ServicerWorkerStrategy,
@@ -82,7 +77,7 @@ func (node *fullNode) NewWorker() {
 }
 
 // start - start worker and cron jobs
-func (node *fullNode) start() {
+func (node *FullNode) start() {
 	logger.Debug(fmt.Sprintf("starting node %s with %d servicers", node.URL, node.Servicers.Size()))
 	node.Crons.Start()
 	node.NewWorker()
@@ -90,7 +85,7 @@ func (node *fullNode) start() {
 }
 
 // stop - stop worker and crons jobs from node
-func (node *fullNode) stop() {
+func (node *FullNode) stop() {
 	logger.Debug(fmt.Sprintf("stopping worker pool of node %s", node.URL))
 	node.Worker.Stop()
 	logger.Debug(fmt.Sprintf("worker pool of node %s stopped!", node.URL))
@@ -105,20 +100,24 @@ func (node *fullNode) stop() {
 }
 
 // checkNodeEndpoint - check node endpoint
-func (node *fullNode) checkNodeEndpoint(endpoint string) error {
+func (node *FullNode) checkNodeEndpoint(endpoint string) error {
 	requestURL := fmt.Sprintf(
 		"%s%s?verify=true",
 		node.URL,
 		endpoint,
 	)
 	req, err := http.NewRequest("POST", requestURL, nil)
+	if err != nil {
+		return err
+	}
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(AuthorizationHeader, servicerAuthToken.Value)
 	if app.GlobalMeshConfig.UserAgent != "" {
 		req.Header.Set("User-Agent", app.GlobalMeshConfig.UserAgent)
 	}
-	resp, err := servicerClient.Do(req)
 
+	resp, err := servicerClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -153,7 +152,7 @@ func (node *fullNode) checkNodeEndpoint(endpoint string) error {
 }
 
 // runCheck - check that node is able to work as expected
-func (node *fullNode) runCheck() error {
+func (node *FullNode) runCheck() error {
 	if node.Servicers.Size() == 0 {
 		return errors.New(fmt.Sprintf("node %s has 0 servicers load.", node.URL))
 	}
@@ -186,10 +185,11 @@ func (node *fullNode) runCheck() error {
 		ServicerCheckEndpoint,
 	)
 	req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(jsonData))
-	req.Header.Set(AuthorizationHeader, servicerAuthToken.Value)
 	if err != nil {
 		return err
 	}
+
+	req.Header.Set(AuthorizationHeader, servicerAuthToken.Value)
 
 	if app.GlobalMeshConfig.UserAgent != "" {
 		req.Header.Set("User-Agent", app.GlobalMeshConfig.UserAgent)
@@ -246,7 +246,7 @@ func (node *fullNode) runCheck() error {
 }
 
 // scheduleNodeChecks - schedule a node heal pooling
-func (node *fullNode) scheduleNodeChecks() {
+func (node *FullNode) scheduleNodeChecks() {
 	_, err := node.Crons.AddFunc(fmt.Sprintf("@every %ds", app.GlobalMeshConfig.NodeCheckInterval), func() {
 		e := node.runCheck()
 		if e != nil {
@@ -265,8 +265,8 @@ func (node *fullNode) scheduleNodeChecks() {
 	}
 }
 
-// GetLatestSessionBlockHeight - same as pocket core code, just a reimplementation base on the info return by fullNode check call.
-func (node *fullNode) GetLatestSessionBlockHeight() (sessionBlockHeight int64) {
+// GetLatestSessionBlockHeight - same as pocket core code, just a reimplementation base on the info return by FullNode check call.
+func (node *FullNode) GetLatestSessionBlockHeight() (sessionBlockHeight int64) {
 	// get the latest block height
 	blockHeight := node.Status.Height
 	// get the blocks per session
@@ -281,8 +281,8 @@ func (node *fullNode) GetLatestSessionBlockHeight() (sessionBlockHeight int64) {
 	return
 }
 
-// createNode - returns a fullNode instance
-func createNode(urlStr, name string) *fullNode {
+// createNode - returns a FullNode instance
+func createNode(urlStr, name string) *FullNode {
 	nodeCronJobsWorker := cron.New()
 
 	if name == "" {
@@ -297,7 +297,7 @@ func createNode(urlStr, name string) *fullNode {
 
 	logger.Debug(fmt.Sprintf("new node name=%s url=%s", name, urlStr))
 
-	node := &fullNode{
+	node := &FullNode{
 		Name:      name,
 		URL:       urlStr,
 		Servicers: xsync.NewMapOf[*servicer](),
@@ -330,7 +330,7 @@ func connectivityChecks(onlyFor mapset.Set[string]) {
 	endpoints := []string{ServicerRelayEndpoint, ServicerSessionEndpoint, ServicerCheckEndpoint}
 
 	// check health for all the servicer nodes before start.
-	nodesMap.Range(func(key string, node *fullNode) bool {
+	nodesMap.Range(func(key string, node *FullNode) bool {
 		// run this check only if something is sent, otherwise (like on first start) it will run for all the nodes.
 		if onlyFor.Cardinality() > 0 && !onlyFor.Contains(key) {
 			// skip node because
@@ -370,7 +370,7 @@ func connectivityChecks(onlyFor mapset.Set[string]) {
 		pond.Strategy(pond.Eager()),
 	)
 
-	nodesMap.Range(func(key string, node *fullNode) bool {
+	nodesMap.Range(func(key string, node *FullNode) bool {
 		// it will not kill the process because sometimes there is errors on the node side that are solved without
 		// need to restart mesh client, like routing one.
 		firstCheckWorker.Submit(func() {

--- a/app/cmd/rpc/mesh/fullnode_test.go
+++ b/app/cmd/rpc/mesh/fullnode_test.go
@@ -18,7 +18,6 @@ RelaySessionBlockHeight = 9
 servicerNodeSessionBlockHeight = 5
 -> return true (node running behind)
 
-
 RelaySessionBlockHeight = 10
 servicerNodeSessionBlockHeight = 5
 -> return false - (node running super behind) or do we want to allow for 2 blocks tolerance
@@ -34,7 +33,7 @@ servicerNodeSessionBlockHeight = 9
 func TestFullNode_ShouldAssumeOptimisticSession(t *testing.T) {
 	type args struct {
 		relay        *pocketTypes.Relay
-		servicerNode *fullNode
+		servicerNode *FullNode
 	}
 	tests := []struct {
 		name string
@@ -51,7 +50,7 @@ func TestFullNode_ShouldAssumeOptimisticSession(t *testing.T) {
 						SessionBlockHeight: 9,
 					},
 				},
-				servicerNode: &fullNode{
+				servicerNode: &FullNode{
 					Status: &app.HealthResponse{
 						Height: 8,
 					},
@@ -69,7 +68,7 @@ func TestFullNode_ShouldAssumeOptimisticSession(t *testing.T) {
 						SessionBlockHeight: 9,
 					},
 				},
-				servicerNode: &fullNode{
+				servicerNode: &FullNode{
 					Status: &app.HealthResponse{
 						Height: 5,
 					},
@@ -86,7 +85,7 @@ func TestFullNode_ShouldAssumeOptimisticSession(t *testing.T) {
 						SessionBlockHeight: 13,
 					},
 				},
-				servicerNode: &fullNode{
+				servicerNode: &FullNode{
 					Status: &app.HealthResponse{
 						Height: 5,
 					},
@@ -104,7 +103,7 @@ func TestFullNode_ShouldAssumeOptimisticSession(t *testing.T) {
 						SessionBlockHeight: 201,
 					},
 				},
-				servicerNode: &fullNode{
+				servicerNode: &FullNode{
 					Status: &app.HealthResponse{
 						Height: 5,
 					},

--- a/app/cmd/rpc/mesh/keys.go
+++ b/app/cmd/rpc/mesh/keys.go
@@ -29,8 +29,8 @@ func getServicersFilePath() string {
 }
 
 // loadServicersFromFile return a sync.Map of nodes/servicers that could be used to start working or calculate a reload
-func loadServicersFromFile() (nodes *xsync.MapOf[string, *fullNode], servicers *xsync.MapOf[string, *servicer]) {
-	nodes = xsync.NewMapOf[*fullNode]()
+func loadServicersFromFile() (nodes *xsync.MapOf[string, *FullNode], servicers *xsync.MapOf[string, *servicer]) {
+	nodes = xsync.NewMapOf[*FullNode]()
 	servicers = xsync.NewMapOf[*servicer]()
 
 	path := getServicersFilePath()
@@ -67,7 +67,7 @@ func loadServicersFromFile() (nodes *xsync.MapOf[string, *fullNode], servicers *
 			}
 
 			for _, n := range readServicers {
-				var node *fullNode
+				var node *FullNode
 
 				if v, ok := nodes.Load(n.URL); !ok {
 					node = createNode(n.URL, n.Name)
@@ -112,7 +112,7 @@ func loadServicersFromFile() (nodes *xsync.MapOf[string, *fullNode], servicers *
 		}
 
 		for index, n := range readServicers {
-			var node *fullNode
+			var node *FullNode
 
 			if v, ok := nodes.Load(n.ServicerUrl); !ok {
 				node = createNode(n.ServicerUrl, "")
@@ -154,7 +154,7 @@ func loadServicersFromFile() (nodes *xsync.MapOf[string, *fullNode], servicers *
 func loadServicerNodes() (totalNodes, totalServicers int) {
 	nodes, servicers := loadServicersFromFile()
 
-	nodes.Range(func(key string, value *fullNode) bool {
+	nodes.Range(func(key string, value *FullNode) bool {
 		nodesMap.Store(key, value)
 		return true
 	})

--- a/app/cmd/rpc/mesh/relay.go
+++ b/app/cmd/rpc/mesh/relay.go
@@ -146,7 +146,7 @@ func notifyServicer(r *pocketTypes.Relay) {
 		// here we are late to notify servicer about the work done, so this session needs to be invalidated, to avoid
 		// new relays and prevent all the code till here on notify
 		LogRelay(r, fmt.Sprintf(
-			"notify - unable to delivery because relay session height is not within tolerance of fullNode session_height=%d",
+			"notify - unable to delivery because relay session height is not within tolerance of FullNode session_height=%d",
 			ns.ServicerNode.Node.GetLatestSessionBlockHeight(),
 		), LogLvlError)
 		ns.ServicerNode.Node.MetricsWorker.AddServiceMetricErrorFor(
@@ -165,7 +165,7 @@ func notifyServicer(r *pocketTypes.Relay) {
 	)
 	req, e3 := retryablehttp.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewBuffer(jsonData))
 	if e3 != nil {
-		LogRelay(r, fmt.Sprintf("notify - error=%s formatting url to call fullNode of servicer", e3.Error()), LogLvlError)
+		LogRelay(r, fmt.Sprintf("notify - error=%s formatting url to call FullNode of servicer", e3.Error()), LogLvlError)
 		ns.ServicerNode.Node.MetricsWorker.AddServiceMetricErrorFor(
 			r.Proof.Blockchain, &ns.ServicerNode.Address,
 			true, NotifyRequestErrorType, "500",
@@ -181,7 +181,7 @@ func notifyServicer(r *pocketTypes.Relay) {
 	resp, e4 := relaysClient.Do(req)
 
 	if e4 != nil {
-		LogRelay(r, fmt.Sprintf("notify - error=%s dispatching relay to fullNode", CleanError(e4.Error())), LogLvlError)
+		LogRelay(r, fmt.Sprintf("notify - error=%s dispatching relay to FullNode", CleanError(e4.Error())), LogLvlError)
 		ns.ServicerNode.Node.MetricsWorker.AddServiceMetricErrorFor(
 			r.Proof.Blockchain, &ns.ServicerNode.Address,
 			true, NotifyRequestErrorType, "500",
@@ -204,7 +204,7 @@ func notifyServicer(r *pocketTypes.Relay) {
 	_, e6 := io.ReadAll(resp.Body)
 	if e6 != nil {
 		LogRelay(r, fmt.Sprintf(
-			"notify - error=%s parsing response from endpoint=%s at fullNode",
+			"notify - error=%s parsing response from endpoint=%s at FullNode",
 			CleanError(e6.Error()), ServicerRelayEndpoint,
 		), LogLvlError)
 		ns.ServicerNode.Node.MetricsWorker.AddServiceMetricErrorFor(
@@ -222,7 +222,7 @@ func notifyServicer(r *pocketTypes.Relay) {
 
 	if !isSuccess {
 		LogRelay(r, fmt.Sprintf(
-			"notify - relay rejected by fullNode with message=%s code=%d codespace=%s",
+			"notify - relay rejected by FullNode with message=%s code=%d codespace=%s",
 			result.Error.Error, result.Error.Code, result.Error.Codespace,
 		), LogLvlError)
 		ns.ServicerNode.Node.MetricsWorker.AddServiceMetricErrorFor(
@@ -231,7 +231,7 @@ func notifyServicer(r *pocketTypes.Relay) {
 		)
 		if result.Error == nil {
 			LogRelay(r, fmt.Sprintf(
-				"EDGE CASE: notify - relay rejected by fullNode without ERROR",
+				"EDGE CASE: notify - relay rejected by FullNode without ERROR",
 			), LogLvlError)
 			requeue = true
 			return
@@ -239,14 +239,6 @@ func notifyServicer(r *pocketTypes.Relay) {
 		evaluateServicerError(r, result.Error)
 	} else {
 		LogRelay(r, "notify - servicer processed relay successfully", LogLvlDebug)
-
-		canHoldMore := ns.CountRelay()
-
-		if !canHoldMore {
-			LogRelay(r, "notify - servicer exhaust relays", LogLvlDebug)
-		} else {
-			LogRelay(r, fmt.Sprintf("notify - servicer has %d remaining relays", ns.RemainingRelays), LogLvlDebug)
-		}
 
 		// track the notification relay time
 		relayDuration := time.Since(relayTimeStart)
@@ -431,29 +423,29 @@ func validate(r *pocketTypes.Relay) (*NodeSession, sdk.Error) {
 }
 
 // HandleRelay - evaluate node status, validate relay payload and call processRelay
-func HandleRelay(r *pocketTypes.Relay) (res *pocketTypes.RelayResponse, dispatch *DispatchResponse, err error) {
+func HandleRelay(r *pocketTypes.Relay) (res *pocketTypes.RelayResponse, dispatch *DispatchResponse, err sdk.Error) {
 	relayTimeStart := time.Now()
 	servicerAddress, e := GetAddressFromPubKeyAsString(r.Proof.ServicerPubKey)
 
 	if e != nil {
-		return nil, nil, errors.New("could not convert servicer hex to public key")
+		return nil, nil, sdk.ErrInternal("Could not convert servicer hex to public key")
 	}
 
 	servicerNode, ok := servicerMap.Load(servicerAddress)
 	if !ok {
-		return nil, nil, errors.New("failed to find correct servicer PK")
+		return nil, nil, sdk.ErrInternal("failed to find correct servicer PK")
 	}
 
 	if servicerNode.Node.Status == nil {
-		return nil, nil, fmt.Errorf("pocket node is currently unavailable")
+		return nil, nil, sdk.ErrInternal("pocket node is currently unavailable")
 	}
 
 	if servicerNode.Node.Status.IsStarting {
-		return nil, nil, fmt.Errorf("pocket node is unable to retrieve synced status from tendermint node, cannot service in this state")
+		return nil, nil, sdk.ErrInternal("pocket node is unable to retrieve synced status from tendermint node, cannot service in this state")
 	}
 
 	if servicerNode.Node.Status.IsCatchingUp {
-		return nil, nil, fmt.Errorf("pocket node is currently syncing to the blockchain, cannot service in this state")
+		return nil, nil, sdk.ErrInternal("pocket node is currently syncing to the blockchain, cannot service in this state")
 	}
 
 	ns, err := validate(r)

--- a/app/cmd/rpc/mesh/servicer.go
+++ b/app/cmd/rpc/mesh/servicer.go
@@ -14,7 +14,7 @@ import (
 type servicer struct {
 	PrivateKey crypto.PrivateKey
 	Address    sdk.Address
-	Node       *fullNode
+	Node       *FullNode
 }
 
 // reloadServicers - read key file again and manipulate current state after detect differences (add/remove)
@@ -27,11 +27,11 @@ func reloadServicers() {
 	reloadedNodes := mapset.NewSet[string]()
 	reloadedServicers := mapset.NewSet[string]()
 
-	nodesMap.Range(func(key string, _ *fullNode) bool {
+	nodesMap.Range(func(key string, _ *FullNode) bool {
 		currentNodes.Add(key)
 		return true
 	})
-	nodes.Range(func(key string, _ *fullNode) bool {
+	nodes.Range(func(key string, _ *FullNode) bool {
 		reloadedNodes.Add(key)
 		return true
 	})
@@ -95,7 +95,7 @@ func reloadServicers() {
 		s, _ := servicers.Load(address)
 		servicerMap.Store(address, s)
 		if node, ok := nodesMap.Load(s.Node.URL); ok {
-			// set the already existent fullNode reference instead of the new one.
+			// set the already existent FullNode reference instead of the new one.
 			s.Node = node
 
 			if orphan, ok := orphanServicers.Load(address); ok {

--- a/app/cmd/rpc/mesh/session.go
+++ b/app/cmd/rpc/mesh/session.go
@@ -114,14 +114,14 @@ type NodeSession struct {
 	ServicerPubKey  string                 // servicer public key
 	ServicerAddress string                 // servicer address
 	BlockHeight     int64                  // session block height
-	Dispatch        *DispatchResponse      // dispatch response from the fullNode
+	Dispatch        *DispatchResponse      // dispatch response from the FullNode
 	Queue           bool                   // flag to know if the async validation of the session is already in queue
 	Queried         bool                   // flag to know if the session was queried to know the validity of it
 	RetryTimes      int                    // how many times the session validation was retried
 	RelayMeta       *pocketTypes.RelayMeta // just a sample of any relay to get the dispatch
 	// servicer related info
 	ServicerNode                *servicer
-	RemainingRelays             int64             // how many relays the servicer can still service - todo: probably will remove and handle the overServiceError from the fullNode
+	RemainingRelays             int64             // how many relays the servicer can still service - todo: probably will remove and handle the overServiceError from the FullNode
 	IsValid                     bool              // if the session is or not valid
 	Error                       *SdkErrorResponse // in case session is not valid anymore, this will be the error to be returned.
 	DuplicateRelayBloomFilter   *bloom.BloomFilter
@@ -286,7 +286,7 @@ func (ns *NodeSession) GetDispatch() (result *RPCSessionResult, statusCode int, 
 		statusCode = NewRequestError
 		e = errors.New(fmt.Sprintf(
 			"error creating check session request app=%s chain=%s blockHeight=%d servicer=%s err=%s",
-			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerAddress, CleanError(e1.Error()),
+			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerAddress, CleanError(e2.Error()),
 		))
 		return
 	}
@@ -302,7 +302,7 @@ func (ns *NodeSession) GetDispatch() (result *RPCSessionResult, statusCode int, 
 		statusCode = ExecuteRequestError
 		e = errors.New(fmt.Sprintf(
 			"error calling check session request app=%s chain=%s blockHeight=%d servicer=%s err=%s",
-			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerAddress, CleanError(e2.Error()),
+			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerAddress, CleanError(e3.Error()),
 		))
 		return
 	}
@@ -323,7 +323,7 @@ func (ns *NodeSession) GetDispatch() (result *RPCSessionResult, statusCode int, 
 		statusCode = ReadAllBodyError // override this to allow caller know when the error was
 		e = errors.New(fmt.Sprintf(
 			"error reading check session response body app=%s chain=%s blockHeight=%d servicer=%s err=%s",
-			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerPubKey, CleanError(e3.Error()),
+			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerPubKey, CleanError(e4.Error()),
 		))
 
 		return
@@ -334,7 +334,7 @@ func (ns *NodeSession) GetDispatch() (result *RPCSessionResult, statusCode int, 
 	if e5 != nil {
 		e = errors.New(fmt.Sprintf(
 			"error unmarshalling check session response to RPCSessionResult app=%s chain=%s blockHeight=%d servicer=%s err=%s",
-			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerAddress, CleanError(e4.Error()),
+			ns.AppPubKey, ns.Chain, ns.BlockHeight, ns.ServicerAddress, CleanError(e5.Error()),
 		))
 		return
 	}
@@ -425,7 +425,7 @@ func (ss *SessionStorage) NewNodeSessionFromRelay(relay *pocketTypes.Relay) (*No
 		RelayMeta:                   &relay.Meta,
 		ServicerNode:                servicerNode,
 		RemainingRelays:             -1,   // means that is unlimited until check it
-		IsValid:                     true, // true until fullNode negate this
+		IsValid:                     true, // true until FullNode negate this
 		Error:                       nil,
 		OptimisticDuplicateRelayMap: xsync.NewMapOf[struct{}](),
 	}, nil

--- a/app/cmd/rpc/mesh/utils.go
+++ b/app/cmd/rpc/mesh/utils.go
@@ -37,7 +37,7 @@ func IsRetryableRelayCode(code sdk.CodeType) bool {
 }
 
 // GetRandomNode - return a random servicer object from the list load at the start
-func GetRandomNode() *fullNode {
+func GetRandomNode() *FullNode {
 	mutex.Lock()
 	address := servicerList[rand.Intn(len(servicerList))]
 	mutex.Unlock()
@@ -59,7 +59,7 @@ func GetAddressFromPubKeyAsString(pubKey string) (string, error) {
 }
 
 // GetNodeFromAddress - lookup a node from a servicer address
-func GetNodeFromAddress(address string) *fullNode {
+func GetNodeFromAddress(address string) *FullNode {
 	s, ok := servicerMap.Load(address)
 
 	if !ok {
@@ -110,7 +110,7 @@ func NewSdkErrorFromPocketSdkError(e sdk.Error) *SdkErrorResponse {
 
 // NewPocketSdkErrorFromSdkError - return a pocketcore sdk.Error from a mesh node sdkErrorResponse
 func NewPocketSdkErrorFromSdkError(e *SdkErrorResponse) sdk.Error {
-	return sdk.NewError(e.Codespace, e.Code, errors.New(e.Error).Error())
+	return sdk.NewError(e.Codespace, e.Code, e.Error)
 }
 
 // ServicerIsSupported - use on pocket node side to verify if the address is handled by the running process.


### PR DESCRIPTION
- Fix an issue with response errors that was serialized twice, so some gateways was not able to property handle when a mesh notify about for example Evidence Sealed error.
- Rollback the session allowance `limit - 1` to just accept the same amount of the servicer.
- Remove the relay counting on mesh, now it will just keep accepting relays until servicer return Code: 90 (Evidence Sealed). This is mostly because sometimes due to restart/crash or other things the count could be wrong and mesh start rejecting relays.
- Rename `fullNode` struct to `FullNode` due to some limitation on exported functions with private struct
